### PR TITLE
Update Dockerfile 现已经支持容器日志输出

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM adlered/tomcat
 
 ADD config.sh /
-RUN chmod 777 /config.sh
 ADD run.sh /
-RUN chmod 777 /run.sh
 ADD bolo.zip /
-RUN unzip -q /bolo.zip -d /apache-tomcat/webapps/ROOT/
+RUN chmod 777 /run.sh \
+    && chmod 777 /config.sh \
+    && unzip -q /bolo.zip -d /apache-tomcat/webapps/ROOT/ \
+    && ln -sf /dev/stdout /apache-tomcat/logs/catalina.out
 RUN echo "Bolo 容器已部署完成！请参考帮助文档以运行 Bolo ！欢迎你的使用。"


### PR DESCRIPTION
更新启动日志，讲tomcat的日志输出链接到标准输出，先已经支持 `docker logs ` 查看容器运行日志。